### PR TITLE
Ensure optional headers are read in SetPath()

### DIFF
--- a/InTheHand.Net.Obex/ObexWebRequest.cs
+++ b/InTheHand.Net.Obex/ObexWebRequest.cs
@@ -867,6 +867,9 @@ namespace InTheHand.Net
             //get code
             sc = (ObexStatusCode)buffer[0];
 
+            // Read optional response headers regardless of the status code.
+            short len = (short)(IPAddress.NetworkToHostOrder(BitConverter.ToInt16(buffer, 1)) - 3);
+            StreamReadBlockMust(ns, buffer, bytesread, len);
         }
 
         #region Check Response


### PR DESCRIPTION
I noticed on an Android device, using PBAP, that errors were occurring because there were leftover bytes to read after calling SetPath(). 