### PR TITLE
Fix blog links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-
-
 # 32feet.NET - Personal Area Networking for .NET
+
 32feet.NET is an open-source project to make personal area networking technologies such as Bluetooth, Infrared (IrDA) and more, easily accessible from .NET code. Supports desktop, mobile or embedded systems.  32feet.NET is free for commercial or non-commercial use. If you use the binaries you can just use the library as-is, if you make modifications to the source you need to include the 32feet.NET License.txt document and ensure the file headers are not modified/removed.  The project currently consists of the following libraries:-
 
 - Bluetooth Classic
@@ -14,6 +13,7 @@
 Bluetooth support requires .NET Framework v4.6.1 for desktop Windows 7, 8 and 10. Android and Apple macOS and iOS are also supported.
 
 ## Downloading
+
 Downloads are available here on the _Downloads_ tab. Packages are also available at NuGet:-
 
 - InTheHand.Net.Bluetooth - Bluetooth Classic (v4.x)
@@ -43,11 +43,13 @@ The user guide is available in the [Wiki](https://github.com/inthehand/32feet/wi
 Please start by reading it.  It contains general information firstly on the various features contained in the library, and on what type of Bluetooth connection you want.  It also contains information on using each feature.
 
 ## Blogs
+
 [Alan's 32feet.NET Development Blog](http://32feetnetdev.wordpress.com/)
 [Peter's Blog](http://inthehand.com/blog)
 
 [In The Hand Ltd](http://inthehand.com)
 
 ## Sponsors
+
 Many thanks to [NDepend](http://www.NDepend.com) for their support.
 Many thanks to [Aton Spa (Italy)](http://www.aton.eu) for commissioning and funding the implementation of StoneStreet One Bluetopia support.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Please start by reading it.  It contains general information firstly on the vari
 ## Blogs
 
 [Alan's 32feet.NET Development Blog](http://32feetnetdev.wordpress.com/)
+
 [Peter's Blog](http://inthehand.com/blog)
 
 [In The Hand Ltd](http://inthehand.com)


### PR DESCRIPTION
This patch does the following,

1. Organize markdown for readability
2. Link the blog link on the same line