### PR TITLE
Fix issue #96

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Windows/BluetoothAdvertisingEvent.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/BluetoothAdvertisingEvent.windows.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;


### PR DESCRIPTION
Fix AdvertisementReceived event always gives e.Device null #96

This is a race condition in the Windows platform.  Essentially, the 'AdvertisementReceived' can fire before the task that sets the "Device" property of the event args completes.