### PR TITLE
Windows disconnect support for BLE

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Android/RemoteGattServer.android.cs
+++ b/InTheHand.BluetoothLE/Platforms/Android/RemoteGattServer.android.cs
@@ -179,6 +179,11 @@ namespace InTheHand.Bluetooth
             _gatt.Disconnect();
         }
 
+        void PlatformCleanup()
+        {
+            // Android has no explicit cleanup 🤪
+        }
+
         async Task<GattService> PlatformGetPrimaryService(BluetoothUuid service)
         {
             await WaitForServiceDiscovery();

--- a/InTheHand.BluetoothLE/Platforms/Apple/RemoteGattServer.unified.cs
+++ b/InTheHand.BluetoothLE/Platforms/Apple/RemoteGattServer.unified.cs
@@ -102,6 +102,10 @@ namespace InTheHand.Bluetooth
         {
         }
 
+        void PlatformCleanup()
+        {
+        }
+
         Task<GattService> PlatformGetPrimaryService(BluetoothUuid service)
         {
             return Task.Run(() =>

--- a/InTheHand.BluetoothLE/Platforms/Standard/RemoteGattServer.standard.cs
+++ b/InTheHand.BluetoothLE/Platforms/Standard/RemoteGattServer.standard.cs
@@ -29,6 +29,10 @@ namespace InTheHand.Bluetooth
         {
         }
 
+        void PlatformCleanup()
+        {
+        }
+
         Task<GattService> PlatformGetPrimaryService(BluetoothUuid service)
         {
             return Task.FromResult((GattService)null);

--- a/InTheHand.BluetoothLE/Platforms/Windows/GattService.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/GattService.windows.cs
@@ -22,6 +22,7 @@ namespace InTheHand.Bluetooth
         {
             _service = service;
             _isPrimary = isPrimary;
+            device.AddDisposableObject(this,service);
         }
 
         public static implicit operator WBluetooth.GattDeviceService(GattService service)

--- a/InTheHand.BluetoothLE/Platforms/Windows/RemoteGattServer.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/RemoteGattServer.windows.cs
@@ -27,20 +27,35 @@ namespace InTheHand.Bluetooth
 
         bool GetConnected()
         {
+            if (Device.IsDisposedItem(Device)) return false;
             return Device.NativeDevice.ConnectionStatus == Windows.Devices.Bluetooth.BluetoothConnectionStatus.Connected;
         }
 
         async Task PlatformConnect()
         {
+            // Ensure that our native objects have not been disposed.
+            // If they have, re-create the native device object.
+            if (await Device.CreateNativeInstance()) PlatformInit();
+
             var status = await Device.NativeDevice.RequestAccessAsync();
             if(status == Windows.Devices.Enumeration.DeviceAccessStatus.Allowed)
             {
+                Device.LastKnownAddress = Device.NativeDevice.BluetoothAddress;
                 var session = await Windows.Devices.Bluetooth.GenericAttributeProfile.GattSession.FromDeviceIdAsync(Device.NativeDevice.BluetoothDeviceId);
                 if(session != null)
+                {
+                    // Even though this is a local variable, we still want to add it to our dispose list so
+                    // we don't have to rely on the GC to clean it up.
+                    Device.AddDisposableObject(this, session);
                     session.MaintainConnection = true;
+                }
 
                 // need to request something to force a connection
-                await Device.NativeDevice.GetGattServicesAsync(cacheMode: Windows.Devices.Bluetooth.BluetoothCacheMode.Uncached);
+                var services = await Device.NativeDevice.GetGattServicesAsync(cacheMode: Windows.Devices.Bluetooth.BluetoothCacheMode.Uncached);
+                foreach (var service in services.Services)
+                {
+                    service.Dispose();
+                }
             }
             else
             {
@@ -53,8 +68,25 @@ namespace InTheHand.Bluetooth
             // Windows has no explicit disconnect 🤪
         }
 
+        void PlatformCleanup()
+        {
+            // The user has explicitly called the Disconnect method so unhook ConnectionStatusChanged
+            // and dispose all of the native windows bluetooth objects.  This will release the device
+            // so that it can be used by another application or re-connected by the current
+            // application.
+            if (Device.NativeDisposeList.TryGetValue(Device.GetHashCode(), out IDisposable existingDevice))
+            {
+                if (existingDevice != null)
+                {
+                    Device.NativeDevice.ConnectionStatusChanged -= NativeDevice_ConnectionStatusChanged;
+                    Device.DisposeAllNativeObjects();
+                }
+            }
+        }
+
         async Task<GattService> PlatformGetPrimaryService(BluetoothUuid service)
         {
+            if (await Device.CreateNativeInstance()) PlatformInit();
             var result = await Device.NativeDevice.GetGattServicesForUuidAsync(service, Windows.Devices.Bluetooth.BluetoothCacheMode.Uncached);
 
             if (result == null || result.Services.Count == 0)
@@ -65,6 +97,7 @@ namespace InTheHand.Bluetooth
 
         async Task<List<GattService>> PlatformGetPrimaryServices(BluetoothUuid? service)
         {
+            if (await Device.CreateNativeInstance()) PlatformInit();
             var services = new List<GattService>();
             var nativeDevice = Device.NativeDevice;
             Windows.Devices.Bluetooth.BluetoothCacheMode cacheMode = nativeDevice.DeviceInformation.Pairing.IsPaired ? Windows.Devices.Bluetooth.BluetoothCacheMode.Cached : Windows.Devices.Bluetooth.BluetoothCacheMode.Uncached;

--- a/InTheHand.BluetoothLE/RemoteGattServer.cs
+++ b/InTheHand.BluetoothLE/RemoteGattServer.cs
@@ -56,6 +56,7 @@ namespace InTheHand.Bluetooth
         {
             PlatformDisconnect();
             Device.OnGattServerDisconnected();
+            PlatformCleanup();
         }
 
         /// <summary>


### PR DESCRIPTION
Dispose native BLE objects when the user explicitly calls RemoteGattServer.Disconnect

This gives the user a way to disconnect bluetooth devices on windows so that they will return to advertising and can be opened by another application or scanned/reconnected by the current one.

Changes are limited to the ".windows.cs" files with the exception of a new "PlatformCleanup" function which is an empty stub in all other platforms.

I tested all the conditions I can think of:
1) User calls Disconnect then scans and re-opens the same device as a new "BluetoothDevice" instance.
2) Bluetooth device is disconnected via a power off and the user calls the "ConnectAsync" method of the original "BluetoothDevice" instance