### PR TITLE
Correctly sets LastSeen time in the DoDiscoverDevices function 

### DIFF
--- a/InTheHand.Net.Bluetooth/Platforms/Win32/BluetoothClient.win32.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Win32/BluetoothClient.win32.cs
@@ -70,10 +70,12 @@ namespace InTheHand.Net.Sockets
             IntPtr searchHandle = NativeMethods.BluetoothFindFirstDevice(ref search, ref device);
             if(searchHandle != IntPtr.Zero)
             {
+                NativeMethods.BluetoothGetDeviceInfo(IntPtr.Zero, ref device);
                 devices.Add(new BluetoothDeviceInfo(device));
 
                 while (NativeMethods.BluetoothFindNextDevice(searchHandle, ref device) && devices.Count < maxDevices)
                 {
+                    NativeMethods.BluetoothGetDeviceInfo(IntPtr.Zero, ref device);
                     devices.Add(new BluetoothDeviceInfo(device));
                 }
 


### PR DESCRIPTION
This looks like a small Windows bug. When using the Windows BluetoothFindFirstDevice & BluetoothFindNextDevice APIs, the "LastSeen" time is not updated properly. A work-a-round is to call the BluetoothGetDeviceInfo API which correctly sets the "LastSeen" member of BLUETOOTH_DEVICE_INFO