### PR TITLE
The Gatt server autoconnect property can be settable by user

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Android/RemoteGattServer.android.cs
+++ b/InTheHand.BluetoothLE/Platforms/Android/RemoteGattServer.android.cs
@@ -48,6 +48,12 @@ namespace InTheHand.Bluetooth
                 _owner = owner;
             }
 
+            public override void OnMtuChanged(ABluetooth.BluetoothGatt gatt, int mtu, [GeneratedEnum] ABluetooth.GattStatus status)
+            {
+                System.Diagnostics.Debug.WriteLine($"OnMtuChanged Status:{status} Size:{mtu}");
+                base.OnMtuChanged(gatt, mtu, status);
+            }
+            
             public override void OnConnectionStateChange(ABluetooth.BluetoothGatt gatt, ABluetooth.GattStatus status, ABluetooth.ProfileState newState)
             {
                 System.Diagnostics.Debug.WriteLine($"ConnectionStateChanged Status:{status} NewState:{newState}");

--- a/InTheHand.BluetoothLE/Platforms/Android/RemoteGattServer.android.cs
+++ b/InTheHand.BluetoothLE/Platforms/Android/RemoteGattServer.android.cs
@@ -20,7 +20,7 @@ namespace InTheHand.Bluetooth
         private void PlatformInit()
         {
             _gattCallback = new GattCallback(this);
-            _gatt = ((ABluetooth.BluetoothDevice)Device).ConnectGatt(Android.App.Application.Context, true, _gattCallback, ABluetooth.BluetoothTransports.Le);
+            _gatt = ((ABluetooth.BluetoothDevice)Device).ConnectGatt(Android.App.Application.Context, AutoConnect, _gattCallback, ABluetooth.BluetoothTransports.Le);
         }
 
         public static implicit operator ABluetooth.BluetoothGatt(RemoteGattServer gatt)

--- a/InTheHand.BluetoothLE/RemoteGattServer.cs
+++ b/InTheHand.BluetoothLE/RemoteGattServer.cs
@@ -14,6 +14,12 @@ namespace InTheHand.Bluetooth
 {
     public sealed partial class RemoteGattServer
     {
+        /// <summary>
+        /// Permit to manage autoconnect in GattServer
+        /// </summary>
+        /// <remarks>available only on monoandroid</remarks>
+        public bool AutoConnect { get; set; } = false;
+        
         internal RemoteGattServer(BluetoothDevice device)
         {
             Device = device;


### PR DESCRIPTION
Some scenarios the auto connect will be disabled for take directly the control of connection,
for example disconnect a device and do somethings and manually call re-connect

The override of OnMtuChanged i have inserted a debug log because Android have some problems when
set different values, it can be set twice with different value for set the correct user desiderated size.

