### PR TITLE
Close connection when call Disconnect

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Apple/RemoteGattServer.unified.cs
+++ b/InTheHand.BluetoothLE/Platforms/Apple/RemoteGattServer.unified.cs
@@ -100,6 +100,8 @@ namespace InTheHand.Bluetooth
 
         void PlatformDisconnect()
         {
+            if (Device != null)
+            { Bluetooth._manager.CancelPeripheralConnection(Device); }
         }
 
         void PlatformCleanup()


### PR DESCRIPTION
add the Bluetooth._manager.CancelPeripheralConnection for close the connection on platform disconnect