### PR TITLE
Adds boolean for requiring MITM protection

### DIFF
--- a/InTheHand.Net.Bluetooth/BluetoothSecurity.cs
+++ b/InTheHand.Net.Bluetooth/BluetoothSecurity.cs
@@ -16,11 +16,12 @@ namespace InTheHand.Net.Bluetooth
         /// Requests the pairing process for the specified device with the provided pin or numeric code.
         /// </summary>
         /// <param name="device"></param>
+        /// <param name="requireMitmProtection">MITM not required only if set to false.</param>
         /// <param name="pin">Optional numeric pin.</param>
         /// <returns></returns>
-        public static bool PairRequest(BluetoothAddress device, string pin = null)
+        public static bool PairRequest(BluetoothAddress device, bool? requireMitmProtection, string pin = null)
         {
-            return PlatformPairRequest(device, pin);
+            return PlatformPairRequest(device, requireMitmProtection, pin);
         }
 
         /// <summary>

--- a/InTheHand.Net.Bluetooth/Platforms/Android/BluetoothSecurity.android.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Android/BluetoothSecurity.android.cs
@@ -27,7 +27,7 @@ namespace InTheHand.Net.Bluetooth
             _adapter = manager.Adapter;
         }
 
-        static bool PlatformPairRequest(BluetoothAddress device, string pin)
+        static bool PlatformPairRequest(BluetoothAddress device, bool? requireMitmProtection, string pin)
         {
             var nativeDevice = _adapter.GetRemoteDevice(device.ToNetworkOrderSixByteArray());
             

--- a/InTheHand.Net.Bluetooth/Platforms/Standard/BluetoothSecurity.standard.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Standard/BluetoothSecurity.standard.cs
@@ -9,7 +9,7 @@ namespace InTheHand.Net.Bluetooth
 {
     partial class BluetoothSecurity
     {
-        static bool PlatformPairRequest(BluetoothAddress device, string pin)
+        static bool PlatformPairRequest(BluetoothAddress device, bool? requireMitmProtection, string pin)
         {
             return false;
         }

--- a/InTheHand.Net.Bluetooth/Platforms/Win32/BluetoothSecurity.win32.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Win32/BluetoothSecurity.win32.cs
@@ -18,7 +18,7 @@ namespace InTheHand.Net.Bluetooth
     {
         private static readonly List<Win32BluetoothAuthentication> _authenticationHandlers = new List<Win32BluetoothAuthentication>();
                 
-        static bool PlatformPairRequest(BluetoothAddress device, string pin)
+        static bool PlatformPairRequest(BluetoothAddress device, bool? requireMitmProtection, string pin)
         {
             if (pin != null)
             {
@@ -42,7 +42,13 @@ namespace InTheHand.Net.Bluetooth
             // Handle response without prompt
             _authenticationHandlers.Add(authHandler);
 
-            bool success = NativeMethods.BluetoothAuthenticateDeviceEx(IntPtr.Zero, IntPtr.Zero, ref info, null, BluetoothAuthenticationRequirements.MITMProtectionRequired) == 0;
+            BluetoothAuthenticationRequirements mitmProtection = BluetoothAuthenticationRequirements.MITMProtectionRequiredBonding;
+            if(requireMitmProtection == false)
+            {
+                mitmProtection = BluetoothAuthenticationRequirements.MITMProtectionNotRequiredBonding;
+            }
+
+            bool success = NativeMethods.BluetoothAuthenticateDeviceEx(IntPtr.Zero, IntPtr.Zero, ref info, null, mitmProtection) == 0;
 
             if (!success)
             {

--- a/InTheHand.Net.Bluetooth/Platforms/Windows/BluetoothSecurity.Windows.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Windows/BluetoothSecurity.Windows.cs
@@ -17,7 +17,7 @@ namespace InTheHand.Net.Bluetooth
     {
         private static Dictionary<string, string> pinMappings = new Dictionary<string, string>();
 
-        static bool PlatformPairRequest(BluetoothAddress device, string pin)
+        static bool PlatformPairRequest(BluetoothAddress device, bool? requireMitmProtection, string pin)
         {
             BluetoothDevice bluetoothDevice = null;
             var t = Task<bool>.Run(async () =>

--- a/InTheHand.Net.Bluetooth/Platforms/iOS/BluetoothSecurity.iOS.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/iOS/BluetoothSecurity.iOS.cs
@@ -11,7 +11,7 @@ namespace InTheHand.Net.Bluetooth
 {
     partial class BluetoothSecurity
     {
-        static bool PlatformPairRequest(BluetoothAddress device, string pin)
+        static bool PlatformPairRequest(BluetoothAddress device, bool? requireMitmProtection, string pin)
         {
             throw new PlatformNotSupportedException();
         }


### PR DESCRIPTION
Sets a nullable boolean argument for PairRequest. On Win32, this allows for MITM protection to be disabled with a false value. MITM protection is enabled by default. On all other platforms, the argument is ignored.