### PR TITLE
GetConnected() on Android using system API call

### DIFF
--- a/InTheHand.Net.Bluetooth/Platforms/Android/BluetoothDeviceInfo.android.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Android/BluetoothDeviceInfo.android.cs
@@ -115,7 +115,9 @@ namespace InTheHand.Net.Sockets
 
         bool GetConnected()
         {
-            return false;
+            Method m = _device.Class.GetMethod("isConnected", null);
+            bool connected = (bool)m.Invoke(_device, null);
+            return connected;
         }
 
         bool GetAuthenticated()


### PR DESCRIPTION
Hello, by calling Android system API it always reflects the current connection state of the device.

Regards
Markus