### PR TITLE
Improve BLE robustness on iOS

### DIFF
--- a/InTheHand.BluetoothLE/GattCharacteristicValueChangedEventArgs.cs
+++ b/InTheHand.BluetoothLE/GattCharacteristicValueChangedEventArgs.cs
@@ -15,14 +15,20 @@ namespace InTheHand.Bluetooth
     /// <seealso cref="GattCharacteristic"/>
     public sealed class GattCharacteristicValueChangedEventArgs : EventArgs
     {
-        internal GattCharacteristicValueChangedEventArgs(byte[] newValue)
+        internal GattCharacteristicValueChangedEventArgs(byte[]? newValue, Exception? error = null)
         {
             Value = newValue;
+            Error = error;
         }
 
         /// <summary>
         /// The new value of the <see cref="GattCharacteristic"/>.
         /// </summary>
-        public byte[] Value { get; private set; }
+        public byte[]? Value { get; private set; }
+
+        /// <summary>
+        /// If set, reports the error occurred in the communication. In such case, <param name="Value" /> is invalid.
+        /// </summary>
+        public Exception? Error { get; private set; }
     }
 }

--- a/InTheHand.BluetoothLE/InTheHand.BluetoothLE.csproj
+++ b/InTheHand.BluetoothLE/InTheHand.BluetoothLE.csproj
@@ -35,6 +35,8 @@
 		<SignAssembly Condition=" '$(Configuration)' == 'Release' ">true</SignAssembly>
 		<AssemblyOriginatorKeyFile Condition=" '$(Configuration)' == 'Release' ">..\\InTheHand.snk</AssemblyOriginatorKeyFile>
 		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">True</GenerateDocumentationFile>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/InTheHand.BluetoothLE/Platforms/Apple/GattCharacteristic.unified.cs
+++ b/InTheHand.BluetoothLE/Platforms/Apple/GattCharacteristic.unified.cs
@@ -179,10 +179,10 @@ namespace InTheHand.Bluetooth
         void AddCharacteristicValueChanged()
         {
             CBPeripheral peripheral = Service.Device;
-            peripheral.UpdatedCharacterteristicValue += Peripheral_UpdatedCharacterteristicValue;
+            peripheral.UpdatedCharacterteristicValue += Peripheral_UpdatedCharacteristicValue;
         }
 
-        void Peripheral_UpdatedCharacterteristicValue(object sender, CBCharacteristicEventArgs e)
+        void Peripheral_UpdatedCharacteristicValue(object sender, CBCharacteristicEventArgs e)
         {
             if (e.Characteristic == _characteristic)
                 OnCharacteristicValueChanged(new GattCharacteristicValueChangedEventArgs(e.Characteristic.Value.ToArray()));
@@ -191,8 +191,8 @@ namespace InTheHand.Bluetooth
         void RemoveCharacteristicValueChanged()
         {
             CBPeripheral peripheral = Service.Device;
-            peripheral.UpdatedCharacterteristicValue -= Peripheral_UpdatedCharacterteristicValue;
-            
+            peripheral.UpdatedCharacterteristicValue -= Peripheral_UpdatedCharacteristicValue;
+
         }
 
         private Task PlatformStartNotifications()


### PR DESCRIPTION
### Avoid connection loop on the BLE device
I saw that whenever there was a connection error with my BLE device, on iOS the phone was trying to connect to it over and over again.
I figured that the BLE driver was missing to call `CancelPeripheralConnection` in case of errors.

### Avoid null exception in case of GATT read errors

If a characteristics is encrypted, the central and peripheral must be paired in order for the central to access the data.
Depending on the BLE device settings, iOS shows a popup for pairing.
If the user cancels the pairing request or the request times out, the Value of the characteristic will be null and a non-null Error will be provided.
The proposed fix handle this correctly, and it provides the error as exception to the upper layers.

#### Enable nullables and use the latest C# language
Nullable are a great tool to get compile-check null errors.
This works only at one condition: all libraries strictly adere to the usage of nullable types.
This aims to be a tiny step in this direction 😃 