### PR TITLE
Make PlatformScanForDevices cancellable by cancellationToken

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Linux/Bluetooth.linux.cs
+++ b/InTheHand.BluetoothLE/Platforms/Linux/Bluetooth.linux.cs
@@ -86,11 +86,15 @@ namespace InTheHand.Bluetooth
             
             Task.Run(async () =>
             {
-                await adapter.StartDiscoveryAsync();
-                await Task.Delay(5000);
-                await adapter.StopDiscoveryAsync();
-                result.TrySetResult(devices);
-            }, cancellationToken);
+                try
+                {
+                    await adapter.StartDiscoveryAsync();
+                    await Task.Delay(60000, cancellationToken);
+                    await adapter.StopDiscoveryAsync();
+                    result.TrySetResult(devices);
+                }
+                catch (TaskCanceledException) {}
+            }, CancellationToken.None);
 
             return await result.Task;
         }


### PR DESCRIPTION
This modification allows StartDiscoveryAsync to be cancelled by the passed-in cancellation token. If the cancellation token is not cancelled within 60 seconds (maybe longer?), StartDiscoveryAsync will automatically cancel itself.
Sometimes we want to customize the scanning time for Bluetooth devices, and if this value is always set to 5 seconds, it may not meet the needs of specific scenarios. Therefore, setting a larger default value and allowing users to cancel scanning at a specified time should make the program more flexible.