### PR TITLE
fix(ble-android): propagate GATT write errors to the application

### DIFF
--- a/InTheHand.BluetoothLE/GattWriteRequestBusyException.cs
+++ b/InTheHand.BluetoothLE/GattWriteRequestBusyException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace InTheHand.Bluetooth
+{
+    public class GattWriteRequestBusyException : Exception
+    {
+        public GattWriteRequestBusyException(string uuid) : base($"Unable to write to the characteristic with {uuid}.")
+        {
+        }
+    }
+}

--- a/InTheHand.BluetoothLE/Platforms/Android/GattCharacteristic.android.cs
+++ b/InTheHand.BluetoothLE/Platforms/Android/GattCharacteristic.android.cs
@@ -121,6 +121,11 @@ namespace InTheHand.Bluetooth
             {
                 int result = ((ABluetooth.BluetoothGatt)Service.Device.Gatt).WriteCharacteristic(_characteristic, value, requireResponse ? (int)ABluetooth.GattWriteType.Default : (int)ABluetooth.GattWriteType.NoResponse);
                 written = result == (int)ABluetooth.CurrentBluetoothStatusCodes.Success;
+
+                if (result == (int)ABluetooth.CurrentBluetoothStatusCodes.ErrorGattWriteRequestBusy)
+                {
+                    return Task.FromException(new GattWriteRequestBusyException(_characteristic.Uuid?.ToString() ?? "N/A"));
+                }
             }
             else
             {


### PR DESCRIPTION
This will give the application a chance to get informed whenever there is an error in the GATT characteristic write operations, and eventually retry the operation.

I was only able to (re)produce this `ErrorGattWriteRequestBusy` error, I'm not sure if there are other errors that should be surfaced as well.
Maybe all errors should be reported?