### PR TITLE
made windows BLE device disposable to allow control of freeing resources

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Windows/BluetoothDevice.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/BluetoothDevice.windows.cs
@@ -15,7 +15,7 @@ using Windows.Devices.Bluetooth;
 
 namespace InTheHand.Bluetooth
 {
-    partial class BluetoothDevice
+    partial class BluetoothDevice : IDisposable
     {
         internal BluetoothLEDevice NativeDevice;
         internal readonly ConcurrentDictionary<int, IDisposable> NativeDisposeList = new ConcurrentDictionary<int, IDisposable>();
@@ -40,7 +40,7 @@ namespace InTheHand.Bluetooth
 
         ~BluetoothDevice()
         {
-            DisposeAllNativeObjects();
+            Dispose(disposing: false);
         }
 
         /// <summary>Adds a native (IDisposable) object to the dispose list</summary>
@@ -249,5 +249,25 @@ namespace InTheHand.Bluetooth
                 _advertisementWatcher.Stop();
             }
         }*/
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                }
+
+                DisposeAllNativeObjects();
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/InTheHand.BluetoothLE/Platforms/Windows/BluetoothDevice.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/BluetoothDevice.windows.cs
@@ -22,6 +22,7 @@ namespace InTheHand.Bluetooth
         private string _cachedId;
         private string _cachedName;
         internal ulong LastKnownAddress;
+        private bool _disposed;
 
         internal BluetoothDevice(BluetoothLEDevice device)
         {
@@ -252,7 +253,7 @@ namespace InTheHand.Bluetooth
 
         private void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -260,7 +261,7 @@ namespace InTheHand.Bluetooth
                 }
 
                 DisposeAllNativeObjects();
-                disposedValue = true;
+                _disposed = true;
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/inthehand/32feet/issues/446

I pared the code down to just the Windows code when i forked this to get it working in my other code, so not sure if applying the `IDisposable` the way I did makes the other OS's happy.