### PR TITLE
Empty Characteristic Reads Throw System.ArgumentException in Windows

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Windows/GattCharacteristic.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/GattCharacteristic.windows.cs
@@ -81,9 +81,9 @@ namespace InTheHand.Bluetooth
             t.Wait();
             var result = t.Result;
 
-            if(result.Status == Uap.GattCommunicationStatus.Success)
+            if (result.Status == Uap.GattCommunicationStatus.Success)
             {
-                return result.Value.ToArray();
+                return result.Value.Length == 0 ? [] : result.Value.ToArray();
             }
 
             return null;
@@ -93,9 +93,9 @@ namespace InTheHand.Bluetooth
         {
             var result = await _characteristic.ReadValueAsync(Windows.Devices.Bluetooth.BluetoothCacheMode.Uncached).AsTask().ConfigureAwait(false);
 
-            if(result.Status == Uap.GattCommunicationStatus.Success)
+            if (result.Status == Uap.GattCommunicationStatus.Success)
             {
-                return result.Value.ToArray();
+                return result.Value.Length == 0 ? [] : result.Value.ToArray();
             }
 
             return null;
@@ -113,7 +113,7 @@ namespace InTheHand.Bluetooth
 
         private void Characteristic_ValueChanged(Uap.GattCharacteristic sender, Uap.GattValueChangedEventArgs args)
         {
-            OnCharacteristicValueChanged(new GattCharacteristicValueChangedEventArgs(args.CharacteristicValue.ToArray()));
+            OnCharacteristicValueChanged(new GattCharacteristicValueChangedEventArgs(args.CharacteristicValue.Length == 0 ? [] : args.CharacteristicValue.ToArray()));
         }
 
         void RemoveCharacteristicValueChanged()

--- a/InTheHand.BluetoothLE/Platforms/Windows/GattDescriptor.windows.cs
+++ b/InTheHand.BluetoothLE/Platforms/Windows/GattDescriptor.windows.cs
@@ -37,7 +37,7 @@ namespace InTheHand.Bluetooth
 
             if (result.Status == Uap.GattCommunicationStatus.Success)
             {
-                return result.Value.ToArray();
+                return result.Value.Length == 0 ? [] : result.Value.ToArray();
             }
 
             return null;
@@ -49,7 +49,7 @@ namespace InTheHand.Bluetooth
 
             if (result.Status == Uap.GattCommunicationStatus.Success)
             {
-                return result.Value.ToArray();
+                return result.Value.Length == 0 ? [] : result.Value.ToArray();
             }
 
             return null;


### PR DESCRIPTION
Zero byte characteristic reads cause the implementation of the `IBuffer.ToArray()` extension method to throw a `System.ArgumentException`. Short-circuit these calls by checking for a buffer length of zero and returning an empty `byte[]` beforehand.

Fixes #396 