### PR TITLE
Support cancellation and timeout for device scanning on Linux

### DIFF
--- a/InTheHand.BluetoothLE/Platforms/Linux/Bluetooth.linux.cs
+++ b/InTheHand.BluetoothLE/Platforms/Linux/Bluetooth.linux.cs
@@ -112,6 +112,7 @@ namespace InTheHand.Bluetooth
                 }
                 catch (TaskCanceledException) 
                 {
+                    await adapter.StopDiscoveryAsync();
                     result.TrySetResult(devices); // if cancelled, return the devices found so far
                 }
                 finally

--- a/InTheHand.BluetoothLE/RequestDeviceOptions.cs
+++ b/InTheHand.BluetoothLE/RequestDeviceOptions.cs
@@ -30,5 +30,10 @@ namespace InTheHand.Bluetooth
         /// If set the request returns all available devices with no filters applied.
         /// </summary>
         public bool AcceptAllDevices { get; set; }
+
+        /// <summary>
+        /// Optional time after which to stop scanning for devices. Currently only supported on Linux.
+        /// </summary>
+        public TimeSpan? Timeout { get; set; }
     }
 }


### PR DESCRIPTION
# My own words

The current implementation for device scanning on Linux accepts a CancellationToken. However, upon cancellation via the token, the method waits indefinitely for the task completion source's task to complete, as the result is never set in case of a cancellation. This can be fixed by allowing the result to be set upon cancellation, enabling us to retrieve the devices found up until that point.

Additionally, I replaced the hard-coded scanning timeout of 60 seconds with an optional property in RequestDeviceOptions.

I also fixed a potential memory leak by removing the event handler from the adapter's DeviceFound event after scanning is done.

# Copilot's two cents

This pull request includes changes to improve the handling of device discovery timeouts and ensure proper cleanup of event handlers in the Bluetooth LE library for Linux.

Improvements to device discovery:

* [`InTheHand.BluetoothLE/Platforms/Linux/Bluetooth.linux.cs`](diffhunk://#diff-a468381e1b58a03fbdd881b97b963a5eaf255ad0ef3b5bf11a2453a04479b1d3R102-R120): Introduced a timeout variable to replace the hardcoded 60,000 milliseconds delay, allowing for customizable timeouts. Added a `finally` block to ensure the `DeviceFound` event handler is always removed after discovery completes or is canceled.

Enhancements to request options:

* [`InTheHand.BluetoothLE/RequestDeviceOptions.cs`](diffhunk://#diff-7e85b393cb94da96675dad2aed7bd805d32677255cb255085084030aa12f7c8eR33-R37): Added an optional `Timeout` property to the `RequestDeviceOptions` class, enabling users to specify a custom timeout for device discovery.