### PR TITLE
Extended class BluetoothDeviceInfo with SerialNumber and ProtocolString

### DIFF
--- a/InTheHand.Net.Bluetooth/BluetoothDeviceInfo.cs
+++ b/InTheHand.Net.Bluetooth/BluetoothDeviceInfo.cs
@@ -99,14 +99,25 @@ namespace InTheHand.Net.Sockets
         /// </summary>
         public bool Authenticated { get => _bluetoothDeviceInfo.Authenticated; }
 
-        
+        /// <summary>
+        /// Gets the serial number of the remote device.
+        /// </summary>
+        public string SerialNumber { get => _bluetoothDeviceInfo.SerialNumber; }
 
         /// <summary>
-        /// Compares two BluetoothDeviceInfo instances for equality.
+        /// On iOS returns the ExternalAccessory Protocol strings for the device.
         /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        public bool Equals(BluetoothDeviceInfo other)
+        /// <remarks>Protocol names are formatted as reverse-DNS strings. For example, the string “com.apple.myProtocol” might represent a custom protocol defined by Apple.
+        /// Manufacturers can define custom protocols for their accessories or work with other manufacturers and organizations to define standard protocols for different accessory types.</remarks>
+        public IReadOnlyCollection<string> ProtocolStrings { get => _bluetoothDeviceInfo.ProtocolStrings; }
+
+
+        /// <summary>
+    /// Compares two BluetoothDeviceInfo instances for equality.
+    /// </summary>
+    /// <param name="other"></param>
+    /// <returns></returns>
+    public bool Equals(BluetoothDeviceInfo other)
         {
             if (other is null)
                 return false;

--- a/InTheHand.Net.Bluetooth/Interfaces/IBluetoothDeviceInfo.cs
+++ b/InTheHand.Net.Bluetooth/Interfaces/IBluetoothDeviceInfo.cs
@@ -26,5 +26,10 @@ namespace InTheHand.Net.Bluetooth
         bool Connected { get; }
 
         bool Authenticated { get; }
-    }
+
+        string SerialNumber { get; }
+
+        IReadOnlyCollection<string> ProtocolStrings { get; }
+
+  }
 }

--- a/InTheHand.Net.Bluetooth/Platforms/Android/BluetoothDeviceInfo.android.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Android/BluetoothDeviceInfo.android.cs
@@ -124,5 +124,10 @@ namespace InTheHand.Net.Sockets
         }
 
         public bool Authenticated {  get => _device.BondState == Bond.Bonded; }
-    }
+
+        public string SerialNumber => string.Empty;
+
+        public IReadOnlyCollection<string> ProtocolStrings => throw new PlatformNotSupportedException();
+
+  }
 }

--- a/InTheHand.Net.Bluetooth/Platforms/Linux/BluetoothDeviceInfo.linux.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Linux/BluetoothDeviceInfo.linux.cs
@@ -102,5 +102,9 @@ namespace InTheHand.Net.Sockets
         {
             Init();
         }
-    }
+
+        public string SerialNumber => string.Empty;
+
+        public IReadOnlyCollection<string> ProtocolStrings => throw new PlatformNotSupportedException();
+  }
 }

--- a/InTheHand.Net.Bluetooth/Platforms/Win32/BluetoothDeviceInfo.win32.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Win32/BluetoothDeviceInfo.win32.cs
@@ -203,5 +203,8 @@ namespace InTheHand.Net.Sockets
                 return _info.LastUsed;
             }
         }
-    }
+        public string SerialNumber => string.Empty;
+
+        public IReadOnlyCollection<string> ProtocolStrings => throw new PlatformNotSupportedException();
+  }
 }

--- a/InTheHand.Net.Bluetooth/Platforms/Windows/BluetoothDeviceInfo.Windows.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/Windows/BluetoothDeviceInfo.Windows.cs
@@ -70,5 +70,9 @@ namespace InTheHand.Net.Sockets
         public bool Connected { get => NativeDevice.ConnectionStatus == BluetoothConnectionStatus.Connected; }
 
         public bool Authenticated { get => NativeDevice.DeviceInformation.Pairing.IsPaired; }
+
+        public string SerialNumber => string.Empty;
+
+        public IReadOnlyCollection<string> ProtocolStrings => throw new PlatformNotSupportedException();
     }
 }

--- a/InTheHand.Net.Bluetooth/Platforms/iOS/BluetoothDeviceInfo.iOS.cs
+++ b/InTheHand.Net.Bluetooth/Platforms/iOS/BluetoothDeviceInfo.iOS.cs
@@ -15,16 +15,6 @@ using System.Collections.ObjectModel;
 
 namespace InTheHand.Net.Sockets
 {
-    partial class BluetoothDeviceInfo
-    {
-        /// <summary>
-        /// On iOS returns the ExternalAccessory Protocol strings for the device.
-        /// </summary>
-        /// <remarks>Protocol names are formatted as reverse-DNS strings. For example, the string “com.apple.myProtocol” might represent a custom protocol defined by Apple.
-        /// Manufacturers can define custom protocols for their accessories or work with other manufacturers and organizations to define standard protocols for different accessory types.</remarks>
-        public IReadOnlyCollection<string> ProtocolStrings => ((ExternalAccessoryBluetoothDeviceInfo)_bluetoothDeviceInfo).ProtocolStrings;
-    }
-
     internal sealed class ExternalAccessoryBluetoothDeviceInfo : IBluetoothDeviceInfo
     {
         private readonly EAAccessory _accessory;
@@ -60,6 +50,8 @@ namespace InTheHand.Net.Sockets
         public bool Authenticated => true;
 
         ClassOfDevice IBluetoothDeviceInfo.ClassOfDevice => (ClassOfDevice)0;
+
+        public string SerialNumber => _accessory.SerialNumber;
 
         void IBluetoothDeviceInfo.Refresh() { }
 


### PR DESCRIPTION
An ExternalAccessory (iOS) has various properties, including frequently used properties such as the device name or the device address. However, it can be useful for an application to also be able to read the serial number and protocol strings, e.g. to be able to filter a list of devices.
As our application only requires these properties on iOS devices, this functionality has only been implemented for iOS. When querying the protocol strings of other platforms, a PlatformNotSupportedException is thrown and an empty string is returned for the serial number.