### PR TITLE
Add net481 to TargetFrameworks for Windows

### DIFF
--- a/InTheHand.BluetoothLE/InTheHand.BluetoothLE.csproj
+++ b/InTheHand.BluetoothLE/InTheHand.BluetoothLE.csproj
@@ -2,7 +2,7 @@
 	<Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);monoandroid10.0;xamarinios10;xamarintvos10;xamarin.watchos10;net8.0-windows10.0.19041.0;uap10.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);monoandroid10.0;xamarinios10;xamarintvos10;xamarin.watchos10;net8.0-windows10.0.19041.0;uap10.0;net481</TargetFrameworks>
 		<Company>In The Hand Ltd</Company>
 		<Authors>Peter Foot</Authors>
 		<Product>32feet.NET</Product>


### PR DESCRIPTION
Needing to use this library in a .NET 4.8.1 project. Currently forked the repo and created a .NET 4.8.1 project ourselves, but would like to just use from NuGET this way.

Not sure if more is needed to make this work.